### PR TITLE
Add Clock Cycle Counter

### DIFF
--- a/target/Dmi.cpp
+++ b/target/Dmi.cpp
@@ -2,7 +2,7 @@
 //
 // This file is part of the Embecosm Debug Server target for CORE-V MCU
 //
-// Copyright (C) 2021 Embecosm Limited
+// Copyright (C) 2022 Embecosm Limited
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
@@ -1814,6 +1814,12 @@ void
 Dmi::Abstractcs::cmderrClear ()
 {
   mAbstractcsReg |= CMDERR_MASK;
+}
+
+uint64_t
+Dmi::simTimeCountNs () const
+{
+  return mDtm->simTimeCountNs();
 }
 
 /// \brief Get the \c datacount bits of \c abstractcs

--- a/target/Dmi.h
+++ b/target/Dmi.h
@@ -2,7 +2,7 @@
 //
 // This file is part of the Embecosm Debug Server target for CORE-V MCU
 //
-// Copyright (C) 2021 Embecosm Limited
+// Copyright (C) 2022 Embecosm Limited
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef DMI_H
@@ -22,6 +22,8 @@
 class Dmi
 {
 public:
+  uint64_t simTimeCountNs () const;
+
   /// \brief The class modeling the abstract \c data registers.
   class Data
   {

--- a/target/DtmJtag.cpp
+++ b/target/DtmJtag.cpp
@@ -2,7 +2,7 @@
 //
 // This file is part of the Embecosm Debug Server target for CORE-V MCU
 //
-// Copyright (C) 2021 Embecosm Limited
+// Copyright (C) 2022 Embecosm Limited
 // SPDX-License-Identifier: Apache-2.0
 
 #include <iomanip>
@@ -187,4 +187,10 @@ void
 DtmJtag::writeDtmcs (const uint32_t val)
 {
   mTap->writeReg (static_cast<uint8_t> (DTMCS), val, 32);
+}
+
+uint64_t
+DtmJtag::simTimeCountNs () const
+{
+  return mTap->simTimeCountNs();
 }

--- a/target/DtmJtag.h
+++ b/target/DtmJtag.h
@@ -2,7 +2,7 @@
 //
 // This file is part of the Embecosm Debug Server target for CORE-V MCU
 //
-// Copyright (C) 2021 Embecosm Limited
+// Copyright (C) 2022 Embecosm Limited
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef DTM_JTAG_H
@@ -27,6 +27,7 @@ public:
   bool reset () override;
   virtual uint32_t dmiRead (uint64_t address) override;
   virtual void dmiWrite (uint64_t address, uint32_t wdata) override;
+  uint64_t simTimeCountNs () const;
 
   // Delete the copy assignment operator
   DtmJtag &operator= (const DtmJtag &) = delete;

--- a/target/IDtm.h
+++ b/target/IDtm.h
@@ -2,7 +2,7 @@
 //
 // This file is part of the Embecosm Debug Server target for CORE-V MCU
 //
-// Copyright (C) 2021 Embecosm Limited
+// Copyright (C) 2022 Embecosm Limited
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef IDTM_H
@@ -26,6 +26,8 @@ public:
   virtual bool reset () = 0;
   virtual uint32_t dmiRead (uint64_t address) = 0;
   virtual void dmiWrite (uint64_t address, uint32_t wdata) = 0;
+
+  virtual uint64_t simTimeCountNs () const = 0;
 
   // Delete the copy assignment operator
   IDtm &operator= (const IDtm &) = delete;

--- a/target/Tap.cpp
+++ b/target/Tap.cpp
@@ -2,7 +2,7 @@
 //
 // This file is part of the Embecosm Debug Server target for CORE-V MCU
 //
-// Copyright (C) 2021 Embecosm Limited
+// Copyright (C) 2022 Embecosm Limited
 // SPDX-License-Identifier: Apache-2.0
 
 #include <iomanip>
@@ -362,4 +362,10 @@ Tap::nameState (const State s) const
     return nameTable[s];
   else
     return "out-of-range";
+}
+
+uint64_t
+Tap::simTimeCountNs () const
+{
+  return mMcu->simTimeCount();
 }

--- a/target/Tap.h
+++ b/target/Tap.h
@@ -2,7 +2,7 @@
 //
 // This file is part of the Embecosm Debug Server target for CORE-V MCU
 //
-// Copyright (C) 2021 Embecosm Limited
+// Copyright (C) 2022 Embecosm Limited
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef TAP_H
@@ -28,6 +28,8 @@ public:
   uint64_t accessReg (const uint8_t ir, uint64_t wdata, const uint8_t len);
   void writeReg (const uint8_t ir, uint64_t wdata, const uint8_t len);
   uint64_t readReg (const uint8_t ir, const uint8_t len);
+
+  uint64_t simTimeCountNs () const;
 
   // Delete the copy assignment operator
   Tap &operator= (const Tap &) = delete;

--- a/target/VSim.cpp
+++ b/target/VSim.cpp
@@ -2,7 +2,7 @@
 //
 // This file is part of the Embecosm Debug Server target for CORE-V MCU
 //
-// Copyright (C) 2021 Embecosm Limited
+// Copyright (C) 2022 Embecosm Limited
 // SPDX-License-Identifier: Apache-2.0
 
 #include <iostream>
@@ -96,6 +96,12 @@ vluint64_t
 VSim::simTimeNs () const
 {
   return mSimTimeTicks;
+}
+
+uint64_t
+VSim::simTimeCount () const 
+{
+  return mTickCount;
 }
 
 /// \brief Determine if we have finished simulating

--- a/target/VSim.h
+++ b/target/VSim.h
@@ -2,7 +2,7 @@
 //
 // This file is part of the Embecosm Debug Server target for CORE-V MCU
 //
-// Copyright (C) 2021 Embecosm Limited
+// Copyright (C) 2022 Embecosm Limited
 // SPDX-License-Identifier: Apache-2.0
 
 #ifndef VSIM_H
@@ -48,6 +48,8 @@ public:
 
   // Delete the copy assignment operator
   VSim &operator= (const VSim &) = delete;
+
+  uint64_t simTimeCount () const;
 
 private:
   /// \brief The verilator simulation context


### PR DESCRIPTION
This patch adds a more sophisticated clock cycle counter to the end of the test, alongside measurements of the real time elapsed, simulated time elapsed, simulation frequency, and slow down factor.

	* Dmi.cpp: Modified.
	* Dmi.h: Likewise.
 	* DtmJtag.cpp: Likewise.
	* DtmJtag.h: Likewise.
	* IDtm.h: Likewise.
	* Tap.cpp: Likewise.
	* Tap.h: Likewise.
	* VSim.cpp: Likewise.
        * VSim.h: Likewise.
        * testbench.cpp: Likewise