### PR TITLE
Implement CV32E40P target for Embdebug.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ else()
   endif()
 endif()
 
+option(CV_MCU_BUILD_DIR "Build directory for CORE-V MCU")
+  if(NOT CV_MCU_BUILD_DIR)
+    message(SEND_ERROR "No include directory specified for CORE-V MCU")
+  endif()
+
 # Configure compiler
 
 # Set C/C++ standards
@@ -41,14 +46,46 @@ if(NOT CMAKE_PROJECT_NAME STREQUAL "embdebug")
   enable_clang_format()
 endif()
 
+set(CXXOPTS_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/targets/embdebug-target-core-v/vendor/cxxopts-3.0.0rc/include)
+
 # EmbDebug target build
 include_directories(${EMBDEBUG_INCLUDE_DIR})
+include_directories(${CV_MCU_BUILD_DIR})
+include_directories(${CXXOPTS_INCLUDE_DIR})
+
+# Get Verilator
+# If it's empty, but pkg-config is available, try using that to find the
+# header directory
+option(VERILATOR_INCLUDE_DIR "Include directory for verilator headers")
+if(NOT VERILATOR_INCLUDE_DIR)
+  message(STATUS "No include directory specified for verilator headers, "
+          "Checking for pkg-config to find verilator headers")
+  find_program(PKG_CONFIG "pkg-config")
+  if(NOT PKG_CONFIG)
+    message(FATAL_ERROR "pkg-config not found, cannot find verilator headers")
+  else()
+    message(STATUS "pkg-config found: ${PKG_CONFIG}.")
+    message(STATUS "Using pkg-config to find verilator headers")
+    execute_process(COMMAND pkg-config --variable=includedir verilator
+                    OUTPUT_VARIABLE VERILATOR_INCLUDE_DIR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT VERILATOR_INCLUDE_DIR)
+      message(FATAL_ERROR "Failed to find verilator headers with pkg-config")
+    else()
+      message(STATUS "Found verilator headers: ${VERILATOR_INCLUDE_DIR}")
+    endif()
+  endif()
+endif()
+
+include_directories(${VERILATOR_INCLUDE_DIR})
 
 # If these files aren't specified as GENERATED at this level then cmake tries
 # to find them at configure time before they have been generated.
-set(CV32E40_EMBDEBUG_TARGET_SRCS target/Cv32e40.cpp)
+set(CV32E40_EMBDEBUG_TARGET_SRCS target/Cv32e40.cpp target/Args.cpp target/DtmJtag.cpp target/Tap.cpp target/TestJtag.cpp target/VSim.cpp target/Dmi.cpp target/Utils.cpp ${VERILATOR_INCLUDE_DIR}/verilated.cpp ${VERILATOR_INCLUDE_DIR}/verilated_vcd_c.cpp)
 
 add_library(embdebug-target-cv32e40 SHARED ${CV32E40_EMBDEBUG_TARGET_SRCS})
+
+target_link_libraries(embdebug-target-cv32e40 ${CV_MCU_BUILD_DIR}/Vcore_v_mcu__ALL.a)
 
 set_target_properties(embdebug-target-cv32e40 PROPERTIES
                       VERSION ${cv32e40_embdebug_target_VERSION}
@@ -62,5 +99,7 @@ message("
   " ${PROJECT_NAME} " version " ${cv32e40_embdebug_target_VERSION} "
   Prefix.......................: " ${CMAKE_INSTALL_PREFIX} "
   C++ Compiler.................: " ${CMAKE_CXX_COMPILER} "
+  cxx-opts.....................: " ${CXXOPTS_INCLUDE_DIR} "
   EmbDebug include directory...: " ${EMBDEBUG_INCLUDE_DIR} "
+  Verilator include directory..: " ${VERILATOR_INCLUDE_DIR} "
   ")

--- a/target/Cv32e40.cpp
+++ b/target/Cv32e40.cpp
@@ -10,42 +10,119 @@
 #include "embdebug/Compat.h"
 #include "embdebug/ITarget.h"
 
+#include <iostream>
+#include <memory>
+
 using namespace EmbDebug;
+
+using namespace std;
+
+#define CV32E40_TARGET_DEBUG 1
+
+/* This bit mask corresponds to the step field of the dcsr register. */
+#define MASK_DCSR_STEP             (1 << 2)
+
+/* This bit mask corresponds to the ebreakm, ebreaks, and ebreaku fields of the dcsr register */
+#define MASK_DCSR_EBREAK_FIELDS    ((1 << 15) | (1 << 13) | (1 << 12))
+
+/* This bit mask corresponds to the cause field of the dcsr register. */
+#define MASK_DCSR_CAUSE_FIELD      0x000001C0
+
+/* This is the bit index where the cause field of the dcsr register begins. */
+#define DCSR_CAUSE_FIELD_START     6
+
+/* This is the value the cause field will be set to if an ebreak instruction was executed. */
+#define DCSR_CAUSE_EBREAK_EXECUTED 1
+
+/* Each register has its own unique number identifier, this is the identifier for PC */
+#define REG_PC_IDENTIFIER          0x20
+
+/* This bit mask corresponds to the field for the first hart in haltsum. */
+#define MASK_HALTSUM_FIRST_HART    1
+
 
 // Instantiate the model. TODO the argument will change to pass in the
 // residual argv.
-Cv32e40::Cv32e40(const TraceFlags *traceFlags EMBDEBUG_ATTR_UNUSED)
-  : ITarget(traceFlags) { return; }
+Cv32e40::Cv32e40(const TraceFlags *traceFlags)
+  : ITarget(traceFlags) {
+  // We create the DTM here, because only at this level do we know what
+  // derived class we will instantiate.  But we then pass ownership to the
+  // DMI, because that is where it belongs.
+  unique_ptr<IDtm> mDtm (new DtmJtag (20, 1000000000,
+                                     ""));
+  unique_ptr<Dmi> mDmi (new Dmi (std::move (mDtm)));
+  // Only one core is present so we can select it at the start
+  mDmi->dtmReset();
+  mDmi->selectHart(0);
+  mDmi->haltHart(0);
+  mDmi->dmcontrol()->read();
+  mDmi->dmcontrol()->prettyPrint(1);
+  mDmi->dmstatus()->prettyPrint(1);
+
+  mDmi->dmstatus()->read();
+
+  // Get sim start time
+  const uint64_t simStart = mDmi->simTimeNs();
+
+  // Move from method local storage to object attributes
+  this->mDmi = std::move(mDmi);
+  this->simStart = simStart;
+  return; 
+}
 
 // Clean up the model
-Cv32e40::~Cv32e40() { return; }
+Cv32e40::~Cv32e40() { 
+  mDmi.reset(nullptr);
+  return; 
+}
 
 // Force termination of the model execution
-ITarget::ResumeRes Cv32e40::terminate() { return ITarget::ResumeRes::NONE; }
+ITarget::ResumeRes Cv32e40::terminate() { 
+  return ITarget::ResumeRes::NONE; 
+}
 
 // Reset the model state
 ITarget::ResumeRes Cv32e40::reset(ITarget::ResetType) {
+  mDmi.reset();
   return ITarget::ResumeRes::SUCCESS;
 }
 
 // Count cycles
-uint64_t Cv32e40::getCycleCount() const { return 0; }
+uint64_t Cv32e40::getCycleCount() const {
+  return mCycleCnt; 
+}
 
 // Count instructions
-uint64_t Cv32e40::getInstrCount() const { return 0; }
+uint64_t Cv32e40::getInstrCount() const {
+  return mInstrCnt;
+}
 
 // How many registers do we have?
-int Cv32e40::getRegisterCount() const { return 32; }
+int Cv32e40::getRegisterCount() const { 
+  return 32; 
+}
 
 // How big is each register in bytes
-int Cv32e40::getRegisterSize() const { return 4; }
+int Cv32e40::getRegisterSize() const { 
+  return 4; 
+}
 
 // Read a register into the VALUE reference argument, returning the number of
 // bytes read
-std::size_t Cv32e40::readRegister(const int reg EMBDEBUG_ATTR_UNUSED,
+std::size_t Cv32e40::readRegister(const int reg,
 				   uint_reg_t &value) {
-  value = 0;
-  return getRegisterSize();
+  std::size_t retval = getRegisterSize();
+
+  uint32_t readvalue; // Need a temp store since we can't pass value.
+  if (reg == REG_PC_IDENTIFIER) {
+    mDmi->readCsr(Dmi::Csr::DPC, readvalue);
+
+  } else {
+    mDmi->readGpr(reg, readvalue);
+  }
+  value=readvalue;
+
+  return retval;
 }
 
 // This is the mechanism for handling host file I/O. It provides a mechanism
@@ -70,60 +147,83 @@ bool Cv32e40::getSyscallArgLocs(SyscallArgLoc &syscallIDLoc,
 
 // Write a register supplied in the VALUE argument and returning the number of
 // bytes written
-std::size_t Cv32e40::writeRegister(const int reg EMBDEBUG_ATTR_UNUSED,
-				    const uint_reg_t value EMBDEBUG_ATTR_UNUSED) {
-  return getRegisterSize();
+std::size_t Cv32e40::writeRegister(const int reg,
+				    const uint_reg_t value) {
+  std::size_t retval = getRegisterSize();
+  if (reg == REG_PC_IDENTIFIER) { // Special case for pc as it is a CSR not GPR
+    mDmi->writeCsr(Dmi::Csr::DPC, value);
+
+  } else {
+    mDmi->writeGpr(reg, value);
+  }
+  return retval;
 }
 
 // Read a block of memory into the supplied buffer, returning the number of
 // bytes read
-std::size_t Cv32e40::read(const uint_addr_t addr EMBDEBUG_ATTR_UNUSED,
-			   uint8_t *buffer EMBDEBUG_ATTR_UNUSED,
+std::size_t Cv32e40::read(const uint_addr_t addr,
+			   uint8_t *buffer,
 			   const std::size_t size) {
-  return size;
+  // We use an intermediary buffer 'buf' before loading into the given buffer.
+  std::size_t retval = size;
+  std::unique_ptr<unsigned char []> buf(new unsigned char [size]);
+  mDmi->readMem(addr, size, buf);
+  for (size_t i = 0; i < size; i++) buffer[i] = buf[i];
+  return retval;;
 }
 
 // Write a block of memory from the supplied buffer, returning the number of
 // bytes read
-std::size_t Cv32e40::write(const uint_addr_t addr EMBDEBUG_ATTR_UNUSED,
-			    const uint8_t *buffer EMBDEBUG_ATTR_UNUSED,
+std::size_t Cv32e40::write(const uint_addr_t addr,
+			    const uint8_t *buffer,
 			    const std::size_t size) {
-  return size;
+  // We use an intermediary buffer 'buf' before loading into the given buffer.
+  std::size_t retval = size;
+  std::unique_ptr<unsigned char []> buf(new unsigned char [size]);
+  for (size_t i = 0; i < size; i++) buf[i] = buffer[i];
+  mDmi->writeMem(addr, size, buf);
+  return retval;
 }
 
 // Insert a matchpoint (breakpoint or watchpoint), returning whether or not
 // this succeeded
-bool Cv32e40::insertMatchpoint(const uint_addr_t EMBDEBUG_ATTR_UNUSED addr,
-				const MatchType EMBDEBUG_ATTR_UNUSED matchType) {
+bool Cv32e40::insertMatchpoint(const uint_addr_t addr,
+				const MatchType matchType) {
   return false;
 }
 
 // Delete a matchpoint (breakpoint or watchpoint), returning whether or not
 // this succeeded
-bool Cv32e40::removeMatchpoint(const uint_addr_t EMBDEBUG_ATTR_UNUSED addr,
-                             const MatchType EMBDEBUG_ATTR_UNUSED matchType) {
+bool Cv32e40::removeMatchpoint(const uint_addr_t addr,
+                             const MatchType matchType) {
   return false;
 }
 
 // Passthru' a command to the target, returning whether or not this succeeded.
-bool Cv32e40::command(const std::string EMBDEBUG_ATTR_UNUSED cmd,
-		       std::ostream EMBDEBUG_ATTR_UNUSED &stream) {
+bool Cv32e40::command(const std::string cmd,
+		       std::ostream &stream) {
   return false;
 }
 
 // Return the time taken by the CPU so far in seconds
-double Cv32e40::timeStamp() { return 0.0; }
+double Cv32e40::timeStamp() {
+  return mCpuTime;
+}
 
 // Return the number of CPUs
-unsigned int Cv32e40::getCpuCount(void) { return 1; }
+unsigned int Cv32e40::getCpuCount(void) { 
+  return 1; // Only one CPU is available
+}
 
 // Return the curent CPU (must be consistent with the number of CPUs, use -1
 // to indicate an invalid response
-unsigned int Cv32e40::getCurrentCpu(void) { return 0; }
+unsigned int Cv32e40::getCurrentCpu(void) {
+  return 0; // Only one CPU is available
+}
 
 // Specify the current CPU
 void Cv32e40::setCurrentCpu(unsigned int num) {
-  assert(num == 0);
+  assert(num == 0); // Only one CPU is available
   return;
 }
 
@@ -131,23 +231,162 @@ void Cv32e40::setCurrentCpu(unsigned int num) {
 // Prepare each core to be resumed. The supplied vector, ACTIONS, says what
 // each core should do when resume is next called. Return whether this
 // succeeded.
-bool Cv32e40::prepare(const std::vector<ITarget::ResumeType> &actions EMBDEBUG_ATTR_UNUSED) {
-  return true;
+bool Cv32e40::prepare(const std::vector<ITarget::ResumeType> &actions) {
+  bool retval = false;
+  if (actions.size() == 1) {
+    mRunAction = actions.at(0);
+    switch (mRunAction) {
+
+      case ITarget::ResumeType::STEP:
+        retval = true;
+        break;
+      case ITarget::ResumeType::CONTINUE:
+        retval = true;
+        break;
+      case ITarget::ResumeType::NONE:
+	break;
+      default:
+        break;
+    }
+  }
+  return retval;
 }
 
 // Resume each core, according to what was specified in the earlier call to
 // prepare. Return whether this succeeded.
 bool Cv32e40::resume(void) {
-  return true;
+  assert(mRunAction != ITarget::ResumeType::NONE); // NONE is invalid on single core machine
+  bool retval = true;
+
+  // Explicitly disable halt request and enable resume request.
+  mDmi->dmcontrol()->haltreq (false);
+
+  if (mRunAction == ITarget::ResumeType::STEP) {
+    // Enable step field of dcsr register.
+    uint32_t dbg_ctrl_val;
+    retval &= mDmi->readCsr(Dmi::Csr::DCSR, dbg_ctrl_val) 
+              == Dmi::Abstractcs::CmderrVal::CMDERR_NONE;
+    dbg_ctrl_val |= MASK_DCSR_STEP;
+    retval &= mDmi->writeCsr(Dmi::Csr::DCSR, dbg_ctrl_val)
+              == Dmi::Abstractcs::CmderrVal::CMDERR_NONE;
+
+  } else if (mRunAction == ITarget::ResumeType::CONTINUE) {
+    // Enable ebreak fields in dcsr register.
+    uint32_t dbg_ctrl_val;
+    retval &= mDmi->readCsr(Dmi::Csr::DCSR, dbg_ctrl_val)
+              == Dmi::Abstractcs::CmderrVal::CMDERR_NONE;
+    dbg_ctrl_val |= MASK_DCSR_EBREAK_FIELDS;
+    retval &= mDmi->writeCsr(Dmi::Csr::DCSR, dbg_ctrl_val)
+              == Dmi::Abstractcs::CmderrVal::CMDERR_NONE;
+  }
+  mDmi->dmcontrol()->resumereq();
+  mDmi->dmcontrol()->write();
+
+  return retval;
 }
 
 // Clock the model waiting for any core to stop
-ITarget::WaitRes Cv32e40::wait(std::vector<ResumeRes> &results EMBDEBUG_ATTR_UNUSED) {
-  return ITarget::WaitRes::TIMEOUT;
+ITarget::WaitRes Cv32e40::wait(std::vector<ResumeRes> &results) {
+
+  assert(mRunAction != ITarget::ResumeType::NONE);
+  ITarget::WaitRes retval = ITarget::WaitRes::ERROR;
+  
+  results.clear();                // Make sure the space for our results is cleared.
+  results.resize(getCpuCount()); // We want to return one result per CPU.
+
+  switch (mRunAction) {
+
+    case ITarget::ResumeType::STEP:
+      retval = stepInstr(results[0]);
+      break;
+
+    case ITarget::ResumeType::CONTINUE:
+      retval = runToBreak(results[0]);
+      break;
+
+    default:
+      std::cerr << "*** ABORT ***: Unknown step type when resuming: "
+                << mRunAction
+                << std::endl;
+      retval = ITarget::WaitRes::ERROR;
+      break;
+  }
+
+  return retval;
 }
 
 // Force all cores to halt, returning whether this was successful
-bool Cv32e40::halt(void) { return true; }
+bool Cv32e40::halt(void) {
+  bool retval = true;
+  
+  mDmi->haltHart (0);
+  mDmstatus->read ();
+  if (!mDmstatus->halted ())
+    {
+      mDmstatus->prettyPrint (false);
+      mDmstatus->prettyPrint (true);
+      retval = false;
+    }
+
+  return retval;
+}
+
+ITarget::WaitRes Cv32e40::stepInstr(ITarget::ResumeRes &resumeRes) {
+  ITarget::WaitRes retval = ITarget::WaitRes::EVENT_OCCURRED;
+  /* Keep going until we halt */
+  uint32_t haltsum_val;
+  while (1) {
+    mDmi->haltsum()->read(0);
+    haltsum_val = mDmi->haltsum()->haltsum(0);
+    /* If hart 1 is halted, break */ 
+    if (haltsum_val & MASK_HALTSUM_FIRST_HART) {
+      resumeRes = ITarget::ResumeRes::INTERRUPTED;
+      break;
+    }
+  }
+  /* Unset the step field. */
+  uint32_t dcsr_val;
+  mDmi->readCsr(Dmi::Csr::DCSR, dcsr_val);
+  dcsr_val &= ~MASK_DCSR_STEP;
+  mDmi->writeCsr(Dmi::Csr::DCSR, dcsr_val);
+
+  return retval;
+}
+
+ITarget::WaitRes Cv32e40::runToBreak(ITarget::ResumeRes &resumeRes) {
+  ITarget::WaitRes retval = ITarget::WaitRes::EVENT_OCCURRED;
+  if (stoppedAtEbreak()) {
+    resumeRes = ITarget::ResumeRes::INTERRUPTED;
+
+  } else {
+    resumeRes = ITarget::ResumeRes::FAILURE;
+  }
+  /* Unset the ebreak fields. */
+  uint32_t dcsr_val;
+  mDmi->readCsr(Dmi::Csr::DCSR, dcsr_val);
+  dcsr_val &= ~MASK_DCSR_EBREAK_FIELDS;
+  mDmi->writeCsr(Dmi::Csr::DCSR, dcsr_val);
+
+  return retval;
+}
+
+bool Cv32e40::stoppedAtEbreak() {
+  /* Keep going until we halt */
+  uint32_t haltsum_val = 0;
+  while (1) {
+    mDmi->haltsum()->read(0);
+    haltsum_val = mDmi->haltsum()->haltsum(0);
+    /* If hart 1 is halted, break */
+    if (haltsum_val & MASK_HALTSUM_FIRST_HART)
+      break;
+  }
+  /* Check if we stopped because of an ebreak */
+  uint32_t dcsr_val;
+  mDmi->readCsr(Dmi::Csr::DCSR, dcsr_val);
+  bool stoppedAtEbreak = ((dcsr_val & MASK_DCSR_CAUSE_FIELD) >> DCSR_CAUSE_FIELD_START) 
+                         == DCSR_CAUSE_EBREAK_EXECUTED;
+  return stoppedAtEbreak;
+}
 
 // Entry point for the shared library
 extern "C" {

--- a/target/Cv32e40.h
+++ b/target/Cv32e40.h
@@ -10,6 +10,10 @@
 #define CV32E40_H
 
 #include "embdebug/ITarget.h"
+#include "Dmi.h"
+#include "DtmJtag.h"
+
+#include <memory>
 
 using namespace EmbDebug;
 
@@ -62,8 +66,18 @@ public:
   virtual const char *getTargetXML(ByteView name) override { return nullptr; }
 
 private:
-  // No private members needed for the template target. This is where you
-  // would place state and helper functions for a real target.
+  ITarget::WaitRes stepInstr(ITarget::ResumeRes &resumeRes);
+  ITarget::WaitRes runToBreak(ITarget::ResumeRes &resumeRes);
+  bool stoppedAtEbreak();
+
+  std::unique_ptr<Dmi> mDmi;
+  uint64_t simStart;
+  uint64_t clkPeriodNs;
+  uint64_t mCpuTime;
+  ITarget::ResumeType mRunAction;
+  uint64_t mCycleCnt;
+  uint64_t mInstrCnt;
+  std::unique_ptr<Dmi::Dmstatus> mDmstatus;
 };
 
 #endif

--- a/target/Makefile
+++ b/target/Makefile
@@ -20,8 +20,7 @@ VERILATED_VCD_C_DEPS ::= $(VINCDIR)/verilated_vcd_c.cpp \
                          $(VINCDIR)/verilated_trace_imp.cpp \
                          $(VINCDIR)/verilated_intrinsics.h
 
-MCU_DIR := $(HOME)/gittrees/openhw/core-v-mcu
-MODEL_DIR ?= $(MCU_DIR)/build/openhwgroup.org_systems_core-v-mcu_0/model-lib-verilator
+MODEL_DIR ?= $(CV_MCU_BUILD_DIR)/build/openhwgroup.org_systems_core-v-mcu_0/model-lib-verilator
 MODEL_LIB ?= $(MODEL_DIR)/obj_dir/Vcore_v_mcu__ALL.a
 
 CXX := g++

--- a/target/VSim.cpp
+++ b/target/VSim.cpp
@@ -52,7 +52,7 @@ VSim::VSim (const vluint64_t clkPeriodNs, const vluint64_t simTimeNs,
   // hard-coded multiples of the clock period.  Easy because we have also hard
   // coded 1 tick = 1ns.
   mClkHalfPeriodTicks = clkPeriodNs / 2;
-  mTckHalfPeriodTicks = mClkHalfPeriodTicks * 10;
+  mTckHalfPeriodTicks = mClkHalfPeriodTicks * 2;
   mResetPeriodTicks = mTckHalfPeriodTicks * 10;
   mSimTimeTicks = simTimeNs;
 


### PR DESCRIPTION
This patch implements the CV32E40P target for embdebug. This allows you to remotely debug a CV32E40P simulator when used with a suitable version of gdb.

	CmakeLists.txt: Modified.
	target/Cv32e40.cpp: Modified.
        target/Cv32e40.h: Modified.
        target/Makefile: Modified.
        target/VSim.cpp: Modified.